### PR TITLE
Example php

### DIFF
--- a/examples_php/README.md
+++ b/examples_php/README.md
@@ -1,0 +1,123 @@
+# libzupt — exemplos PHP com FFI
+
+Esta pasta contém exemplos PHP equivalentes aos exemplos de `examples_python`, usando diretamente a ABI C da `libzupt` por meio da extensão PHP FFI.
+
+## Requisitos
+
+- Linux ou macOS;
+- PHP 8.1 ou superior;
+- extensão `FFI` carregada;
+- `libzupt.so`/`libzupt.dylib` compilada ou instalada;
+- símbolos da ABI C definidos em `include/zupt_cxx.h`.
+
+Verifique o ambiente:
+
+```bash
+php -v
+php -m | grep -i '^FFI$'
+```
+
+## Compilar a libzupt
+
+A partir da raiz do projeto:
+
+```bash
+mkdir -p build
+cmake -S . -B build
+cmake --build build -j"$(nproc)"
+```
+
+O wrapper procura automaticamente, nesta ordem:
+
+1. caminho informado ao construtor de `ZuptFFI`;
+2. variável `LIBZUPT_PATH`;
+3. `build/libzupt.so` na raiz do projeto;
+4. caminhos comuns do sistema e nomes disponíveis pelo carregador dinâmico.
+
+Para informar explicitamente o arquivo:
+
+```bash
+export LIBZUPT_PATH="$PWD/build/libzupt.so"
+```
+
+Se a biblioteca foi instalada em um diretório não padrão, também pode ser necessário:
+
+```bash
+export LD_LIBRARY_PATH="$(dirname "$LIBZUPT_PATH"):${LD_LIBRARY_PATH:-}"
+```
+
+## Executar
+
+```bash
+cd examples_php
+php -d ffi.enable=1 example_basic.php
+php -d ffi.enable=1 example_file.php
+php -d ffi.enable=1 example_keygen.php
+php -d ffi.enable=1 example_random.php
+php -d ffi.enable=1 example_secure_buffer.php
+```
+
+Ou todos de uma vez:
+
+```bash
+./run_all.sh
+```
+
+## Exemplos
+
+- `example_basic.php`: geração de chaves e criptografia/descriptografia em memória;
+- `example_file.php`: criptografia e restauração de arquivo;
+- `example_keygen.php`: salvar, carregar e exportar chaves;
+- `example_random.php`: bytes aleatórios, SHA-256 e SHA3-512;
+- `example_secure_buffer.php`: buffer nativo zerável para reduzir a permanência de dados sensíveis;
+- `Zupt.php`: wrapper FFI reutilizável.
+
+## Uso mínimo
+
+```php
+<?php
+require_once __DIR__ . '/Zupt.php';
+
+$zupt = new ZuptFFI();
+$keys = $zupt->generateKeyPair();
+
+$encrypted = $zupt->encrypt($keys['publicKey'], 'mensagem secreta');
+$plaintext = $zupt->decrypt(
+    $keys['secretKey'],
+    $encrypted['ciphertext'],
+    $encrypted['encHeader']
+);
+
+echo $plaintext, PHP_EOL;
+```
+
+## Formato e tamanhos usados
+
+Os valores abaixo seguem a implementação atual da ABI C:
+
+- chave pública híbrida: `1224` bytes;
+- chave privada híbrida: `3656` bytes;
+- header de criptografia: `1137` bytes;
+- composição: ML-KEM-768 + X25519.
+
+O ciphertext e o header são dados binários. Não use funções de texto que possam alterar bytes ou codificação.
+
+## Segurança do `ZuptSecureBuffer`
+
+`ZuptSecureBuffer` aloca memória nativa e a preenche com zeros quando `zeroize()` é chamado ou quando o objeto é destruído. Isso reduz a permanência do conteúdo naquele buffer específico.
+
+O PHP pode manter cópias temporárias em strings, logs, exceções ou estruturas internas. Portanto, o exemplo não oferece uma garantia absoluta de eliminação de todos os vestígios da informação no processo.
+
+## Observação sobre Windows
+
+A ABI atual retorna buffers alocados por `malloc()` e não fornece uma função pública `zupt_free()`. Para evitar liberar memória com um runtime C incompatível, estes exemplos bloqueiam a execução no Windows. Uma evolução recomendada da ABI é exportar:
+
+```c
+void zupt_free(void *ptr);
+```
+
+Assim PHP, Node.js e outras linguagens poderão devolver buffers à mesma biblioteca de forma portátil.
+
+## Licença
+
+SPDX-License-Identifier: MIT

--- a/examples_php/README.md
+++ b/examples_php/README.md
@@ -1,25 +1,25 @@
-# libzupt — exemplos PHP com FFI
+# libzupt — PHP FFI Examples
 
-Esta pasta contém exemplos PHP equivalentes aos exemplos de `examples_python`, usando diretamente a ABI C da `libzupt` por meio da extensão PHP FFI.
+This directory contains PHP examples equivalent to those in `examples_python`, using the `libzupt` C ABI directly through the PHP FFI extension.
 
-## Requisitos
+## Requirements
 
-- Linux ou macOS;
-- PHP 8.1 ou superior;
-- extensão `FFI` carregada;
-- `libzupt.so`/`libzupt.dylib` compilada ou instalada;
-- símbolos da ABI C definidos em `include/zupt_cxx.h`.
+* Linux or macOS;
+* PHP 8.1 or later;
+* the `FFI` extension enabled;
+* a compiled or installed `libzupt.so`/`libzupt.dylib`;
+* C ABI symbols defined in `include/zupt_cxx.h`.
 
-Verifique o ambiente:
+Check your environment:
 
 ```bash
 php -v
 php -m | grep -i '^FFI$'
 ```
 
-## Compilar a libzupt
+## Building libzupt
 
-A partir da raiz do projeto:
+From the project root directory:
 
 ```bash
 mkdir -p build
@@ -27,26 +27,26 @@ cmake -S . -B build
 cmake --build build -j"$(nproc)"
 ```
 
-O wrapper procura automaticamente, nesta ordem:
+The wrapper searches for the library in the following order:
 
-1. caminho informado ao construtor de `ZuptFFI`;
-2. variável `LIBZUPT_PATH`;
-3. `build/libzupt.so` na raiz do projeto;
-4. caminhos comuns do sistema e nomes disponíveis pelo carregador dinâmico.
+1. the path passed to the `ZuptFFI` constructor;
+2. the `LIBZUPT_PATH` environment variable;
+3. `build/libzupt.so` in the project root directory;
+4. common system paths and library names available through the dynamic loader.
 
-Para informar explicitamente o arquivo:
+To explicitly specify the library file:
 
 ```bash
 export LIBZUPT_PATH="$PWD/build/libzupt.so"
 ```
 
-Se a biblioteca foi instalada em um diretório não padrão, também pode ser necessário:
+If the library was installed in a non-standard directory, you may also need to set:
 
 ```bash
 export LD_LIBRARY_PATH="$(dirname "$LIBZUPT_PATH"):${LD_LIBRARY_PATH:-}"
 ```
 
-## Executar
+## Running the Examples
 
 ```bash
 cd examples_php
@@ -57,22 +57,22 @@ php -d ffi.enable=1 example_random.php
 php -d ffi.enable=1 example_secure_buffer.php
 ```
 
-Ou todos de uma vez:
+Or run all examples at once:
 
 ```bash
 ./run_all.sh
 ```
 
-## Exemplos
+## Examples
 
-- `example_basic.php`: geração de chaves e criptografia/descriptografia em memória;
-- `example_file.php`: criptografia e restauração de arquivo;
-- `example_keygen.php`: salvar, carregar e exportar chaves;
-- `example_random.php`: bytes aleatórios, SHA-256 e SHA3-512;
-- `example_secure_buffer.php`: buffer nativo zerável para reduzir a permanência de dados sensíveis;
-- `Zupt.php`: wrapper FFI reutilizável.
+* `example_basic.php`: key generation and in-memory encryption/decryption;
+* `example_file.php`: file encryption and restoration;
+* `example_keygen.php`: save, load, and export keys;
+* `example_random.php`: random bytes, SHA-256, and SHA3-512;
+* `example_secure_buffer.php`: zeroizable native buffer designed to reduce the lifetime of sensitive data in memory;
+* `Zupt.php`: reusable FFI wrapper.
 
-## Uso mínimo
+## Minimal Usage
 
 ```php
 <?php
@@ -81,7 +81,7 @@ require_once __DIR__ . '/Zupt.php';
 $zupt = new ZuptFFI();
 $keys = $zupt->generateKeyPair();
 
-$encrypted = $zupt->encrypt($keys['publicKey'], 'mensagem secreta');
+$encrypted = $zupt->encrypt($keys['publicKey'], 'secret message');
 $plaintext = $zupt->decrypt(
     $keys['secretKey'],
     $encrypted['ciphertext'],
@@ -91,33 +91,35 @@ $plaintext = $zupt->decrypt(
 echo $plaintext, PHP_EOL;
 ```
 
-## Formato e tamanhos usados
+## Data Format and Sizes
 
-Os valores abaixo seguem a implementação atual da ABI C:
+The values below follow the current C ABI implementation:
 
-- chave pública híbrida: `1224` bytes;
-- chave privada híbrida: `3656` bytes;
-- header de criptografia: `1137` bytes;
-- composição: ML-KEM-768 + X25519.
+* hybrid public key: `1224` bytes;
+* hybrid private key: `3656` bytes;
+* encryption header: `1137` bytes;
+* composition: ML-KEM-768 + X25519.
 
-O ciphertext e o header são dados binários. Não use funções de texto que possam alterar bytes ou codificação.
+The ciphertext and encryption header contain binary data. Do not use text-processing functions that may alter their bytes or encoding.
 
-## Segurança do `ZuptSecureBuffer`
+## `ZuptSecureBuffer` Security Considerations
 
-`ZuptSecureBuffer` aloca memória nativa e a preenche com zeros quando `zeroize()` é chamado ou quando o objeto é destruído. Isso reduz a permanência do conteúdo naquele buffer específico.
+`ZuptSecureBuffer` allocates native memory and overwrites it with zeros when `zeroize()` is called or when the object is destroyed. This reduces the lifetime of the contents stored in that specific buffer.
 
-O PHP pode manter cópias temporárias em strings, logs, exceções ou estruturas internas. Portanto, o exemplo não oferece uma garantia absoluta de eliminação de todos os vestígios da informação no processo.
+PHP may retain temporary copies in strings, logs, exceptions, or internal data structures. Therefore, this example does not provide an absolute guarantee that every trace of the information will be removed from the process memory.
 
-## Observação sobre Windows
+## Windows Note
 
-A ABI atual retorna buffers alocados por `malloc()` e não fornece uma função pública `zupt_free()`. Para evitar liberar memória com um runtime C incompatível, estes exemplos bloqueiam a execução no Windows. Uma evolução recomendada da ABI é exportar:
+The current ABI returns buffers allocated with `malloc()` and does not provide a public `zupt_free()` function. To avoid freeing memory through an incompatible C runtime, these examples prevent execution on Windows.
+
+A recommended ABI improvement is to export:
 
 ```c
 void zupt_free(void *ptr);
 ```
 
-Assim PHP, Node.js e outras linguagens poderão devolver buffers à mesma biblioteca de forma portátil.
+This would allow PHP, Node.js, and other languages to safely return allocated buffers to the same library in a portable manner.
 
-## Licença
+## License
 
 SPDX-License-Identifier: MIT

--- a/examples_php/Zupt.php
+++ b/examples_php/Zupt.php
@@ -1,0 +1,537 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PHP FFI wrapper for libzupt.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+final class ZuptFFI
+{
+    public const MLKEM_PUBLIC_KEY_SIZE = 1184;
+    public const MLKEM_PRIVATE_KEY_SIZE = 2400;
+    public const X25519_KEY_SIZE = 32;
+    public const HYBRID_PUBLIC_KEY_SIZE = 1224;
+    public const HYBRID_PRIVATE_KEY_SIZE = 3656;
+    public const HYBRID_ENCRYPTION_HEADER_SIZE = 1137;
+    public const AES_NONCE_SIZE = 16;
+
+    private const CDEF = <<<'CDEF'
+        int zupt_hybrid_keygen_c(uint8_t *pub_key, uint8_t *priv_key);
+        int zupt_hybrid_export_pubkey_c(const uint8_t *priv_key, uint8_t *pub_key);
+
+        uint8_t *zupt_read_file(const char *path, size_t *size);
+        int zupt_write_file(const char *path, const uint8_t *data, size_t size);
+
+        uint8_t *zupt_hybrid_encrypt(
+            const uint8_t *pub_key,
+            size_t pub_key_len,
+            const uint8_t *plaintext,
+            size_t plaintext_len,
+            uint8_t *enc_header,
+            size_t *enc_header_len,
+            size_t *ciphertext_len
+        );
+
+        uint8_t *zupt_hybrid_decrypt(
+            const uint8_t *priv_key,
+            size_t priv_key_len,
+            const uint8_t *ciphertext,
+            size_t ciphertext_len,
+            const uint8_t *enc_header,
+            size_t enc_header_len,
+            size_t *plaintext_len
+        );
+
+        void zupt_random_bytes(uint8_t *buf, size_t len);
+        void zupt_sha256(const uint8_t *data, size_t len, uint8_t out[32]);
+        void zupt_sha3_512(const uint8_t *data, size_t len, uint8_t out[64]);
+
+        void free(void *ptr);
+    CDEF;
+
+    private FFI $ffi;
+    private string $libraryPath;
+
+    public function __construct(?string $libraryPath = null)
+    {
+        if (!extension_loaded('FFI')) {
+            throw new RuntimeException('A extensão PHP FFI não está carregada.');
+        }
+
+        if (PHP_OS_FAMILY === 'Windows') {
+            throw new RuntimeException(
+                'Estes exemplos usam free() do runtime Unix. Execute em Linux/macOS ou adicione uma função zupt_free() à ABI para Windows.'
+            );
+        }
+
+        [$this->ffi, $this->libraryPath] = $this->loadLibrary($libraryPath);
+    }
+
+    public function getLibraryPath(): string
+    {
+        return $this->libraryPath;
+    }
+
+    /** @return array{publicKey:string, secretKey:string} */
+    public function generateKeyPair(): array
+    {
+        $publicKey = $this->ffi->new('uint8_t[' . self::HYBRID_PUBLIC_KEY_SIZE . ']');
+        $privateKey = $this->ffi->new('uint8_t[' . self::HYBRID_PRIVATE_KEY_SIZE . ']');
+
+        $result = $this->ffi->zupt_hybrid_keygen_c($publicKey, $privateKey);
+        if ($result !== 0) {
+            throw new RuntimeException('Falha ao gerar o par de chaves híbridas.');
+        }
+
+        return [
+            'publicKey' => FFI::string($publicKey, self::HYBRID_PUBLIC_KEY_SIZE),
+            'secretKey' => FFI::string($privateKey, self::HYBRID_PRIVATE_KEY_SIZE),
+        ];
+    }
+
+    public function exportPublicKey(string $privateKey): string
+    {
+        $this->assertLength($privateKey, self::HYBRID_PRIVATE_KEY_SIZE, 'chave privada');
+
+        $privateBuffer = $this->stringToBuffer($privateKey);
+        $publicBuffer = $this->ffi->new('uint8_t[' . self::HYBRID_PUBLIC_KEY_SIZE . ']');
+
+        $result = $this->ffi->zupt_hybrid_export_pubkey_c($privateBuffer, $publicBuffer);
+        if ($result !== 0) {
+            throw new RuntimeException('Falha ao exportar a chave pública.');
+        }
+
+        return FFI::string($publicBuffer, self::HYBRID_PUBLIC_KEY_SIZE);
+    }
+
+    /**
+     * @param array{publicKey:string, secretKey:string} $keyPair
+     */
+    public function saveKeyPair(array $keyPair, string $privatePath, ?string $publicPath = null): void
+    {
+        $this->assertLength($keyPair['publicKey'] ?? '', self::HYBRID_PUBLIC_KEY_SIZE, 'chave pública');
+        $this->assertLength($keyPair['secretKey'] ?? '', self::HYBRID_PRIVATE_KEY_SIZE, 'chave privada');
+
+        $this->writeBinaryFile($privatePath, $keyPair['secretKey'], 0600);
+        if ($publicPath !== null) {
+            $this->writeBinaryFile($publicPath, $keyPair['publicKey'], 0644);
+        }
+    }
+
+    /** @return array{publicKey:string, secretKey:string} */
+    public function loadKeyPair(string $privatePath): array
+    {
+        $privateKey = $this->readBinaryFile($privatePath);
+        $this->assertLength($privateKey, self::HYBRID_PRIVATE_KEY_SIZE, 'arquivo de chave privada');
+
+        return [
+            'publicKey' => $this->exportPublicKey($privateKey),
+            'secretKey' => $privateKey,
+        ];
+    }
+
+    public function loadPublicKey(string $publicPath): string
+    {
+        $publicKey = $this->readBinaryFile($publicPath);
+        $this->assertLength($publicKey, self::HYBRID_PUBLIC_KEY_SIZE, 'arquivo de chave pública');
+
+        return $publicKey;
+    }
+
+    /** @return array{ciphertext:string, encHeader:string} */
+    public function encrypt(string $publicKey, string $plaintext): array
+    {
+        if ($plaintext === '') {
+            throw new InvalidArgumentException('A API atual da libzupt não retorna um buffer para plaintext vazio.');
+        }
+
+        $plaintextBuffer = $this->stringToBuffer($plaintext);
+        return $this->encryptPointer($publicKey, $plaintextBuffer, strlen($plaintext));
+    }
+
+    /** @return array{ciphertext:string, encHeader:string} */
+    public function encryptSecure(string $publicKey, ZuptSecureBuffer $plaintext): array
+    {
+        if ($plaintext->size() === 0) {
+            throw new InvalidArgumentException('O SecureBuffer não pode estar vazio.');
+        }
+
+        return $this->encryptPointer($publicKey, $plaintext->pointer(), $plaintext->size());
+    }
+
+    public function decrypt(
+        string $privateKey,
+        string $ciphertext,
+        string $encHeader
+    ): string {
+        [$pointer, $length] = $this->decryptPointer($privateKey, $ciphertext, $encHeader);
+
+        try {
+            return FFI::string($pointer, $length);
+        } finally {
+            if ($length > 0) {
+                FFI::memset($pointer, 0, $length);
+            }
+            $this->ffi->free($pointer);
+        }
+    }
+
+    public function decryptSecure(
+        string $privateKey,
+        string $ciphertext,
+        string $encHeader
+    ): ZuptSecureBuffer {
+        [$pointer, $length] = $this->decryptPointer($privateKey, $ciphertext, $encHeader);
+
+        try {
+            $buffer = new ZuptSecureBuffer($length);
+            $buffer->copyFromPointer($pointer, $length);
+            return $buffer;
+        } finally {
+            if ($length > 0) {
+                FFI::memset($pointer, 0, $length);
+            }
+            $this->ffi->free($pointer);
+        }
+    }
+
+    /** @return array{ciphertext:string, encHeader:string} */
+    public function encryptFile(
+        string $publicKey,
+        string $inputPath,
+        string $ciphertextPath,
+        string $headerPath
+    ): array {
+        $plaintext = $this->readBinaryFile($inputPath);
+        $encrypted = $this->encrypt($publicKey, $plaintext);
+
+        $this->writeBinaryFile($ciphertextPath, $encrypted['ciphertext'], 0600);
+        $this->writeBinaryFile($headerPath, $encrypted['encHeader'], 0600);
+
+        return $encrypted;
+    }
+
+    public function decryptFile(
+        string $privateKey,
+        string $ciphertextPath,
+        string $headerPath,
+        string $outputPath
+    ): string {
+        $ciphertext = $this->readBinaryFile($ciphertextPath);
+        $encHeader = $this->readBinaryFile($headerPath);
+        $plaintext = $this->decrypt($privateKey, $ciphertext, $encHeader);
+
+        $this->writeBinaryFile($outputPath, $plaintext, 0600);
+        return $plaintext;
+    }
+
+    public function randomBytes(int $length): string
+    {
+        if ($length < 1) {
+            throw new InvalidArgumentException('O tamanho deve ser maior que zero.');
+        }
+
+        $buffer = $this->ffi->new("uint8_t[$length]");
+        $this->ffi->zupt_random_bytes($buffer, $length);
+        return FFI::string($buffer, $length);
+    }
+
+    public function sha256(string $data): string
+    {
+        $input = $this->stringToBuffer($data);
+        $output = $this->ffi->new('uint8_t[32]');
+        $this->ffi->zupt_sha256($input, strlen($data), $output);
+        return FFI::string($output, 32);
+    }
+
+    public function sha3_512(string $data): string
+    {
+        $input = $this->stringToBuffer($data);
+        $output = $this->ffi->new('uint8_t[64]');
+        $this->ffi->zupt_sha3_512($input, strlen($data), $output);
+        return FFI::string($output, 64);
+    }
+
+    /**
+     * @return array{ciphertext:string, encHeader:string}
+     */
+    private function encryptPointer(string $publicKey, FFI\CData $plaintext, int $plaintextLength): array
+    {
+        $this->assertLength($publicKey, self::HYBRID_PUBLIC_KEY_SIZE, 'chave pública');
+
+        $publicKeyBuffer = $this->stringToBuffer($publicKey);
+        $header = $this->ffi->new('uint8_t[' . self::HYBRID_ENCRYPTION_HEADER_SIZE . ']');
+        $headerLength = $this->ffi->new('size_t[1]');
+        $ciphertextLength = $this->ffi->new('size_t[1]');
+        $headerLength[0] = self::HYBRID_ENCRYPTION_HEADER_SIZE;
+        $ciphertextLength[0] = 0;
+
+        $ciphertext = $this->ffi->zupt_hybrid_encrypt(
+            $publicKeyBuffer,
+            self::HYBRID_PUBLIC_KEY_SIZE,
+            $plaintext,
+            $plaintextLength,
+            $header,
+            $headerLength,
+            $ciphertextLength
+        );
+
+        if ($ciphertext === null || FFI::isNull($ciphertext)) {
+            throw new RuntimeException('Falha na criptografia híbrida da libzupt.');
+        }
+
+        $cipherLength = (int) $ciphertextLength[0];
+        $actualHeaderLength = (int) $headerLength[0];
+
+        try {
+            if ($actualHeaderLength !== self::HYBRID_ENCRYPTION_HEADER_SIZE) {
+                throw new RuntimeException(
+                    "Header inesperado: {$actualHeaderLength} bytes; esperado: " . self::HYBRID_ENCRYPTION_HEADER_SIZE
+                );
+            }
+
+            return [
+                'ciphertext' => FFI::string($ciphertext, $cipherLength),
+                'encHeader' => FFI::string($header, $actualHeaderLength),
+            ];
+        } finally {
+            $this->ffi->free($ciphertext);
+        }
+    }
+
+    /** @return array{0:FFI\CData,1:int} */
+    private function decryptPointer(
+        string $privateKey,
+        string $ciphertext,
+        string $encHeader
+    ): array {
+        $this->assertLength($privateKey, self::HYBRID_PRIVATE_KEY_SIZE, 'chave privada');
+        $this->assertLength($encHeader, self::HYBRID_ENCRYPTION_HEADER_SIZE, 'header de criptografia');
+
+        if ($ciphertext === '') {
+            throw new InvalidArgumentException('O ciphertext não pode estar vazio.');
+        }
+
+        $privateKeyBuffer = $this->stringToBuffer($privateKey);
+        $ciphertextBuffer = $this->stringToBuffer($ciphertext);
+        $headerBuffer = $this->stringToBuffer($encHeader);
+        $plaintextLength = $this->ffi->new('size_t[1]');
+        $plaintextLength[0] = 0;
+
+        $plaintext = $this->ffi->zupt_hybrid_decrypt(
+            $privateKeyBuffer,
+            self::HYBRID_PRIVATE_KEY_SIZE,
+            $ciphertextBuffer,
+            strlen($ciphertext),
+            $headerBuffer,
+            self::HYBRID_ENCRYPTION_HEADER_SIZE,
+            $plaintextLength
+        );
+
+        if ($plaintext === null || FFI::isNull($plaintext)) {
+            throw new RuntimeException(
+                'Falha na descriptografia: chave incorreta, dados corrompidos ou autenticação inválida.'
+            );
+        }
+
+        return [$plaintext, (int) $plaintextLength[0]];
+    }
+
+    private function stringToBuffer(string $data): FFI\CData
+    {
+        $length = strlen($data);
+        $buffer = $this->ffi->new('uint8_t[' . max(1, $length) . ']');
+        if ($length > 0) {
+            FFI::memcpy($buffer, $data, $length);
+        }
+        return $buffer;
+    }
+
+    private function assertLength(string $data, int $expected, string $label): void
+    {
+        $actual = strlen($data);
+        if ($actual !== $expected) {
+            throw new InvalidArgumentException(
+                sprintf('Tamanho inválido para %s: %d bytes; esperado: %d bytes.', $label, $actual, $expected)
+            );
+        }
+    }
+
+    private function readBinaryFile(string $path): string
+    {
+        if (!is_file($path)) {
+            throw new RuntimeException("Arquivo não encontrado: {$path}");
+        }
+
+        $data = file_get_contents($path);
+        if ($data === false) {
+            throw new RuntimeException("Não foi possível ler o arquivo: {$path}");
+        }
+
+        return $data;
+    }
+
+    private function writeBinaryFile(string $path, string $data, int $permissions): void
+    {
+        $directory = dirname($path);
+        if (!is_dir($directory) && !mkdir($directory, 0700, true) && !is_dir($directory)) {
+            throw new RuntimeException("Não foi possível criar o diretório: {$directory}");
+        }
+
+        $bytes = file_put_contents($path, $data, LOCK_EX);
+        if ($bytes === false || $bytes !== strlen($data)) {
+            throw new RuntimeException("Não foi possível gravar o arquivo: {$path}");
+        }
+
+        @chmod($path, $permissions);
+    }
+
+    /** @return array{0:FFI,1:string} */
+    private function loadLibrary(?string $explicitPath): array
+    {
+        $candidates = [];
+
+        if ($explicitPath !== null && $explicitPath !== '') {
+            $candidates[] = $explicitPath;
+        }
+
+        $environmentPath = getenv('LIBZUPT_PATH');
+        if (is_string($environmentPath) && $environmentPath !== '') {
+            $candidates[] = $environmentPath;
+        }
+
+        $projectRoot = dirname(__DIR__);
+        foreach ([
+            $projectRoot . '/build/libzupt.so',
+            $projectRoot . '/build/libzupt.so.1',
+            $projectRoot . '/build/libzupt.dylib',
+            '/usr/local/lib64/libzupt.so',
+            '/usr/local/lib/libzupt.so',
+            '/usr/lib64/libzupt.so',
+            '/usr/lib/libzupt.so',
+            'libzupt.so.1',
+            'libzupt.so',
+            'libzupt.dylib',
+        ] as $candidate) {
+            $candidates[] = $candidate;
+        }
+
+        $candidates = array_values(array_unique($candidates));
+        $errors = [];
+
+        foreach ($candidates as $candidate) {
+            if (str_contains($candidate, DIRECTORY_SEPARATOR) && !is_file($candidate)) {
+                continue;
+            }
+
+            try {
+                return [FFI::cdef(self::CDEF, $candidate), $candidate];
+            } catch (Throwable $error) {
+                $errors[] = $candidate . ': ' . $error->getMessage();
+            }
+        }
+
+        $details = $errors === [] ? 'nenhum candidato existente foi encontrado' : implode("\n", $errors);
+        throw new RuntimeException(
+            "Não foi possível carregar a libzupt. Defina LIBZUPT_PATH=/caminho/libzupt.so.\n{$details}"
+        );
+    }
+}
+
+/**
+ * Native buffer whose allocated bytes are wiped on zeroize/destruction.
+ *
+ * PHP strings created before or after this object are managed by the PHP runtime
+ * and cannot be guaranteed to be erased.
+ */
+final class ZuptSecureBuffer
+{
+    private FFI\CData $buffer;
+    private int $length;
+    private bool $zeroized = false;
+
+    public function __construct(string|int $source)
+    {
+        if (is_int($source)) {
+            if ($source < 0) {
+                throw new InvalidArgumentException('O tamanho do buffer não pode ser negativo.');
+            }
+            $this->length = $source;
+            $this->buffer = FFI::new('uint8_t[' . max(1, $source) . ']');
+            if ($source > 0) {
+                FFI::memset($this->buffer, 0, $source);
+            }
+            $this->zeroized = true;
+            return;
+        }
+
+        $this->length = strlen($source);
+        $this->buffer = FFI::new('uint8_t[' . max(1, $this->length) . ']');
+        if ($this->length > 0) {
+            FFI::memcpy($this->buffer, $source, $this->length);
+            $this->zeroized = false;
+        } else {
+            $this->zeroized = true;
+        }
+    }
+
+    public function size(): int
+    {
+        return $this->length;
+    }
+
+    public function pointer(): FFI\CData
+    {
+        return $this->buffer;
+    }
+
+    public function toString(): string
+    {
+        return $this->length === 0 ? '' : FFI::string($this->buffer, $this->length);
+    }
+
+    public function copyFromPointer(FFI\CData $source, int $length): void
+    {
+        if ($length < 0 || $length > $this->length) {
+            throw new InvalidArgumentException('Tamanho inválido para cópia no SecureBuffer.');
+        }
+
+        if ($length > 0) {
+            FFI::memcpy($this->buffer, $source, $length);
+            $this->zeroized = false;
+        }
+    }
+
+    public function zeroize(): void
+    {
+        if ($this->length > 0 && !$this->zeroized) {
+            FFI::memset($this->buffer, 0, $this->length);
+        }
+        $this->zeroized = true;
+    }
+
+    public function isZeroized(): bool
+    {
+        if (!$this->zeroized) {
+            return false;
+        }
+
+        for ($index = 0; $index < $this->length; $index++) {
+            if ($this->buffer[$index] !== 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function __destruct()
+    {
+        $this->zeroize();
+    }
+
+    private function __clone(): void
+    {
+    }
+}

--- a/examples_php/example_basic.php
+++ b/examples_php/example_basic.php
@@ -1,0 +1,63 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/Zupt.php';
+
+try {
+    $zupt = new ZuptFFI();
+
+    echo str_repeat('=', 60), PHP_EOL;
+    echo "libzupt - Exemplo básico PHP/FFI", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL, PHP_EOL;
+    echo "Biblioteca: {$zupt->getLibraryPath()}", PHP_EOL, PHP_EOL;
+
+    echo "1. Gerando par de chaves...", PHP_EOL;
+    $keyPair = $zupt->generateKeyPair();
+    echo '   Chave pública: ', strlen($keyPair['publicKey']), " bytes", PHP_EOL;
+    echo '   Chave privada: ', strlen($keyPair['secretKey']), " bytes", PHP_EOL, PHP_EOL;
+
+    $message = 'Hello, Post-Quantum World! This is a secret message.';
+    echo "2. Criptografando: {$message}", PHP_EOL;
+    $encrypted = $zupt->encrypt($keyPair['publicKey'], $message);
+    echo '   Ciphertext: ', strlen($encrypted['ciphertext']), " bytes", PHP_EOL;
+    echo '   Header: ', strlen($encrypted['encHeader']), " bytes", PHP_EOL, PHP_EOL;
+
+    echo "3. Descriptografando...", PHP_EOL;
+    $decrypted = $zupt->decrypt(
+        $keyPair['secretKey'],
+        $encrypted['ciphertext'],
+        $encrypted['encHeader']
+    );
+    echo "   Resultado: {$decrypted}", PHP_EOL, PHP_EOL;
+
+    if (!hash_equals($message, $decrypted)) {
+        throw new RuntimeException('A mensagem descriptografada não corresponde à original.');
+    }
+    echo "4. Verificação: SUCESSO", PHP_EOL, PHP_EOL;
+
+    echo "5. Testando uma chave incorreta...", PHP_EOL;
+    $wrongKeyPair = $zupt->generateKeyPair();
+    $wrongKeyRejected = false;
+    try {
+        $zupt->decrypt(
+            $wrongKeyPair['secretKey'],
+            $encrypted['ciphertext'],
+            $encrypted['encHeader']
+        );
+    } catch (RuntimeException $error) {
+        $wrongKeyRejected = true;
+        echo "   Rejeitada corretamente: {$error->getMessage()}", PHP_EOL;
+    }
+
+    if (!$wrongKeyRejected) {
+        throw new RuntimeException('A descriptografia com chave incorreta deveria ter falhado.');
+    }
+
+    echo PHP_EOL, str_repeat('=', 60), PHP_EOL;
+    echo "Exemplo concluído com sucesso!", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL;
+} catch (Throwable $error) {
+    fwrite(STDERR, 'ERRO: ' . $error->getMessage() . PHP_EOL);
+    exit(1);
+}

--- a/examples_php/example_file.php
+++ b/examples_php/example_file.php
@@ -1,0 +1,72 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/Zupt.php';
+
+$directory = sys_get_temp_dir() . '/libzupt_php_file_' . bin2hex(random_bytes(4));
+
+try {
+    $zupt = new ZuptFFI();
+    if (!mkdir($directory, 0700, true) && !is_dir($directory)) {
+        throw new RuntimeException("Não foi possível criar {$directory}");
+    }
+
+    $inputPath = $directory . '/secret.txt';
+    $cipherPath = $directory . '/secret.txt.enc';
+    $headerPath = $directory . '/secret.txt.header';
+    $outputPath = $directory . '/secret.decrypted.txt';
+
+    $original = "This is a secret text file.\n"
+        . "Line 2: Contains sensitive information.\n"
+        . "Line 3: End of file.\n";
+    file_put_contents($inputPath, $original, LOCK_EX);
+
+    echo str_repeat('=', 60), PHP_EOL;
+    echo "libzupt - Exemplo de arquivo PHP/FFI", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL, PHP_EOL;
+
+    echo "1. Gerando chaves...", PHP_EOL;
+    $keyPair = $zupt->generateKeyPair();
+
+    echo "2. Arquivo criado: {$inputPath}", PHP_EOL;
+    echo $original, PHP_EOL;
+
+    echo "3. Criptografando arquivo...", PHP_EOL;
+    $encrypted = $zupt->encryptFile(
+        $keyPair['publicKey'],
+        $inputPath,
+        $cipherPath,
+        $headerPath
+    );
+    echo '   Ciphertext: ', strlen($encrypted['ciphertext']), " bytes", PHP_EOL;
+    echo '   Header: ', strlen($encrypted['encHeader']), " bytes", PHP_EOL;
+
+    echo "4. Descriptografando arquivo...", PHP_EOL;
+    $decrypted = $zupt->decryptFile(
+        $keyPair['secretKey'],
+        $cipherPath,
+        $headerPath,
+        $outputPath
+    );
+    echo "   Arquivo restaurado: {$outputPath}", PHP_EOL;
+
+    if (!hash_equals($original, $decrypted)) {
+        throw new RuntimeException('O arquivo restaurado difere do original.');
+    }
+
+    echo "5. Verificação: SUCESSO", PHP_EOL;
+    echo PHP_EOL, str_repeat('=', 60), PHP_EOL;
+    echo "Exemplo de arquivo concluído!", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL;
+} catch (Throwable $error) {
+    fwrite(STDERR, 'ERRO: ' . $error->getMessage() . PHP_EOL);
+    exit(1);
+} finally {
+    if (is_dir($directory)) {
+        foreach (glob($directory . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($directory);
+    }
+}

--- a/examples_php/example_keygen.php
+++ b/examples_php/example_keygen.php
@@ -1,0 +1,75 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/Zupt.php';
+
+$directory = sys_get_temp_dir() . '/libzupt_php_keys_' . bin2hex(random_bytes(4));
+
+try {
+    $zupt = new ZuptFFI();
+    if (!mkdir($directory, 0700, true) && !is_dir($directory)) {
+        throw new RuntimeException("Não foi possível criar {$directory}");
+    }
+
+    $privatePath = $directory . '/private.zupt-key';
+    $publicPath = $directory . '/public.zupt-key';
+
+    echo str_repeat('=', 60), PHP_EOL;
+    echo "libzupt - Geração e gerenciamento de chaves PHP/FFI", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL, PHP_EOL;
+
+    echo "1. Gerando par de chaves...", PHP_EOL;
+    $keyPair = $zupt->generateKeyPair();
+    echo '   Pública: ', strlen($keyPair['publicKey']), " bytes", PHP_EOL;
+    echo '   Privada: ', strlen($keyPair['secretKey']), " bytes", PHP_EOL, PHP_EOL;
+
+    echo "2. Salvando chaves...", PHP_EOL;
+    $zupt->saveKeyPair($keyPair, $privatePath, $publicPath);
+    echo "   Privada: {$privatePath}", PHP_EOL;
+    echo "   Pública: {$publicPath}", PHP_EOL, PHP_EOL;
+
+    echo "3. Exportando a chave pública a partir da privada...", PHP_EOL;
+    $exportedPublic = $zupt->exportPublicKey($keyPair['secretKey']);
+    if (!hash_equals($keyPair['publicKey'], $exportedPublic)) {
+        throw new RuntimeException('A chave pública exportada não corresponde à original.');
+    }
+    echo "   Chave pública exportada corretamente.", PHP_EOL, PHP_EOL;
+
+    echo "4. Carregando o par de chaves...", PHP_EOL;
+    $loadedPair = $zupt->loadKeyPair($privatePath);
+    if (!hash_equals($keyPair['publicKey'], $loadedPair['publicKey'])
+        || !hash_equals($keyPair['secretKey'], $loadedPair['secretKey'])) {
+        throw new RuntimeException('As chaves carregadas não correspondem às originais.');
+    }
+    echo "   Par de chaves validado.", PHP_EOL, PHP_EOL;
+
+    echo "5. Carregando apenas a chave pública...", PHP_EOL;
+    $loadedPublic = $zupt->loadPublicKey($publicPath);
+    if (!hash_equals($keyPair['publicKey'], $loadedPublic)) {
+        throw new RuntimeException('A chave pública carregada não corresponde à original.');
+    }
+    echo "   Chave pública validada.", PHP_EOL, PHP_EOL;
+
+    echo "6. Tamanhos da ABI:", PHP_EOL;
+    echo '   ML-KEM pública: ', ZuptFFI::MLKEM_PUBLIC_KEY_SIZE, " bytes", PHP_EOL;
+    echo '   ML-KEM privada: ', ZuptFFI::MLKEM_PRIVATE_KEY_SIZE, " bytes", PHP_EOL;
+    echo '   X25519: ', ZuptFFI::X25519_KEY_SIZE, " bytes", PHP_EOL;
+    echo '   Híbrida pública: ', ZuptFFI::HYBRID_PUBLIC_KEY_SIZE, " bytes", PHP_EOL;
+    echo '   Híbrida privada: ', ZuptFFI::HYBRID_PRIVATE_KEY_SIZE, " bytes", PHP_EOL;
+    echo '   Header: ', ZuptFFI::HYBRID_ENCRYPTION_HEADER_SIZE, " bytes", PHP_EOL;
+
+    echo PHP_EOL, str_repeat('=', 60), PHP_EOL;
+    echo "Exemplo de chaves concluído!", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL;
+} catch (Throwable $error) {
+    fwrite(STDERR, 'ERRO: ' . $error->getMessage() . PHP_EOL);
+    exit(1);
+} finally {
+    if (is_dir($directory)) {
+        foreach (glob($directory . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($directory);
+    }
+}

--- a/examples_php/example_random.php
+++ b/examples_php/example_random.php
@@ -1,0 +1,41 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/Zupt.php';
+
+try {
+    $zupt = new ZuptFFI();
+
+    echo str_repeat('=', 60), PHP_EOL;
+    echo "libzupt - Aleatoriedade e hashes PHP/FFI", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL, PHP_EOL;
+
+    echo "1. Gerando 32 bytes aleatórios...", PHP_EOL;
+    $random = $zupt->randomBytes(32);
+    echo '   ', bin2hex($random), PHP_EOL, PHP_EOL;
+
+    echo "2. Gerando nonce AES...", PHP_EOL;
+    $nonce = $zupt->randomBytes(ZuptFFI::AES_NONCE_SIZE);
+    echo '   ', bin2hex($nonce), PHP_EOL, PHP_EOL;
+
+    $data = 'Hello, Post-Quantum World!';
+    echo "3. SHA-256 de '{$data}'...", PHP_EOL;
+    echo '   ', bin2hex($zupt->sha256($data)), PHP_EOL, PHP_EOL;
+
+    echo "4. SHA3-512 de '{$data}'...", PHP_EOL;
+    echo '   ', bin2hex($zupt->sha3_512($data)), PHP_EOL, PHP_EOL;
+
+    echo "5. Simulando derivação simples...", PHP_EOL;
+    $salt = $zupt->randomBytes(16);
+    $derived = $zupt->sha256($salt . 'my-secret-password');
+    echo '   Salt: ', bin2hex($salt), PHP_EOL;
+    echo '   Chave derivada: ', bin2hex($derived), PHP_EOL;
+
+    echo PHP_EOL, str_repeat('=', 60), PHP_EOL;
+    echo "Exemplo de aleatoriedade concluído!", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL;
+} catch (Throwable $error) {
+    fwrite(STDERR, 'ERRO: ' . $error->getMessage() . PHP_EOL);
+    exit(1);
+}

--- a/examples_php/example_secure_buffer.php
+++ b/examples_php/example_secure_buffer.php
@@ -1,0 +1,55 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+require_once __DIR__ . '/Zupt.php';
+
+try {
+    $zupt = new ZuptFFI();
+
+    echo str_repeat('=', 60), PHP_EOL;
+    echo "libzupt - SecureBuffer PHP/FFI", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL, PHP_EOL;
+
+    echo "1. Criando SecureBuffer com conteúdo...", PHP_EOL;
+    $secretText = 'My secret password123';
+    $secretBuffer = new ZuptSecureBuffer($secretText);
+    unset($secretText);
+    echo '   Tamanho: ', $secretBuffer->size(), " bytes", PHP_EOL;
+    echo '   Conteúdo: ', $secretBuffer->toString(), PHP_EOL, PHP_EOL;
+
+    echo "2. Criando SecureBuffer vazio de 64 bytes...", PHP_EOL;
+    $emptyBuffer = new ZuptSecureBuffer(64);
+    echo '   Tamanho: ', $emptyBuffer->size(), " bytes", PHP_EOL;
+    echo '   Zerado: ', $emptyBuffer->isZeroized() ? 'sim' : 'não', PHP_EOL, PHP_EOL;
+
+    echo "3. Criptografando diretamente do SecureBuffer...", PHP_EOL;
+    $keyPair = $zupt->generateKeyPair();
+    $encrypted = $zupt->encryptSecure($keyPair['publicKey'], $secretBuffer);
+    echo '   Ciphertext: ', strlen($encrypted['ciphertext']), " bytes", PHP_EOL, PHP_EOL;
+
+    echo "4. Descriptografando para SecureBuffer...", PHP_EOL;
+    $decryptedBuffer = $zupt->decryptSecure(
+        $keyPair['secretKey'],
+        $encrypted['ciphertext'],
+        $encrypted['encHeader']
+    );
+    echo '   Tamanho: ', $decryptedBuffer->size(), " bytes", PHP_EOL;
+    echo '   Conteúdo: ', $decryptedBuffer->toString(), PHP_EOL, PHP_EOL;
+
+    if (!hash_equals($secretBuffer->toString(), $decryptedBuffer->toString())) {
+        throw new RuntimeException('O conteúdo do SecureBuffer não corresponde após descriptografia.');
+    }
+    echo "5. Verificação: SUCESSO", PHP_EOL, PHP_EOL;
+
+    echo "6. Zerando o buffer original...", PHP_EOL;
+    $secretBuffer->zeroize();
+    echo '   Zerado: ', $secretBuffer->isZeroized() ? 'sim' : 'não', PHP_EOL;
+
+    echo PHP_EOL, str_repeat('=', 60), PHP_EOL;
+    echo "Exemplo de SecureBuffer concluído!", PHP_EOL;
+    echo str_repeat('=', 60), PHP_EOL;
+} catch (Throwable $error) {
+    fwrite(STDERR, 'ERRO: ' . $error->getMessage() . PHP_EOL);
+    exit(1);
+}

--- a/examples_php/run_all.sh
+++ b/examples_php/run_all.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+for example in \
+    example_basic.php \
+    example_file.php \
+    example_keygen.php \
+    example_random.php \
+    example_secure_buffer.php
+do
+    printf '\n>>> Executando %s\n\n' "$example"
+    php -d ffi.enable=1 "$example"
+done


### PR DESCRIPTION
### Add PHP FFI examples for libzupt

* Add a reusable PHP FFI wrapper for the libzupt C ABI
* Add examples for in-memory encryption, file encryption, key management, random byte generation, hashing, and secure buffers
* Add automatic shared library path detection with support for `LIBZUPT_PATH`
* Add a script to run all PHP examples
* Add English documentation with build, configuration, usage, security, and platform notes
* Document the current hybrid key and encryption header sizes
* Prevent execution on Windows until the ABI exposes a portable memory-release function
